### PR TITLE
Add areas facet key

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -4,7 +4,7 @@ require 'gds_api/helpers'
 class Scheme < OpenStruct
   extend GdsApi::Helpers
 
-  FACET_KEYS = [:business_sizes, :locations, :sectors, :stages, :support_types]
+  FACET_KEYS = [:areas, :business_sizes, :locations, :sectors, :stages, :support_types]
 
   def self.lookup(params={})
 
@@ -35,7 +35,7 @@ class Scheme < OpenStruct
 
   def self.area_identifiers(postcode)
     areas_response = imminence_api.areas_for_postcode(postcode)
-    areas = areas_response["results"].map { |area| area["id"] }
+    areas = areas_response["results"].map { |area| area["slug"] }
     areas.join(",")
   end
 end

--- a/spec/features/search_business_support_spec.rb
+++ b/spec/features/search_business_support_spec.rb
@@ -34,14 +34,14 @@ describe "Search for business support" do
     end
     it "should filter the schemes by facet values" do
        facets = {
+          "areas" => ["london"],
           "business_sizes" => ["up-to-249"],
-          "locations" => ["london"],
           "sectors" => ["education"],
           "stages" => ["grow-and-sustain"]
         }
       content_api_has_business_support_scheme(@graduate_start_up_attrs.merge(facets), facets)
 
-      visit "/business-support-schemes.json?business_sizes=up-to-249&locations=london&sectors=education&stages=grow-and-sustain"
+      visit "/business-support-schemes.json?areas=london&business_sizes=up-to-249&sectors=education&stages=grow-and-sustain"
 
       parsed_response = JSON.parse(page.body)
       parsed_response["total"].should == 1
@@ -51,21 +51,20 @@ describe "Search for business support" do
       parsed_response["pages"].should == 1
       results = parsed_response["results"]
       results.first["title"].should == "Graduate start-up scheme"
-      results.first["locations"].should == ["london"]
+      results.first["areas"].should == ["london"]
     end
 
     it "should filter the schemes by facet values and areas" do
-      imminence_has_areas_for_postcode("WC2B%206SE",[{"id" => 3, "name" => "London"}])
+      imminence_has_areas_for_postcode("WC2B%206SE",[{"slug" => "london", "name" => "London"}])
       facets = {
-          "areas" => ["1", "3", "77"],
+          "areas" => ["london", "wales", "scotland"],
           "business_sizes" => ["up-to-249"],
-          "locations" => ["london"],
           "sectors" => ["education"],
           "stages" => ["grow-and-sustain"]
         }
       content_api_has_business_support_scheme(@graduate_start_up_attrs.merge(facets), facets)
 
-      visit "/business-support-schemes.json?postcode=WC2B%206SE&business_sizes=up-to-249&locations=london&sectors=education&stages=grow-and-sustain"
+      visit "/business-support-schemes.json?postcode=WC2B%206SE&business_sizes=up-to-249&sectors=education&stages=grow-and-sustain"
 
       parsed_response = JSON.parse(page.body)
       parsed_response["total"].should == 1
@@ -75,8 +74,7 @@ describe "Search for business support" do
       parsed_response["pages"].should == 1
       results = parsed_response["results"]
       results.first["title"].should == "Graduate start-up scheme"
-      results.first["locations"].should == ["london"]
-      results.first["areas"].should == ["1","3","77"]
+      results.first["areas"].should == ["london","wales","scotland"]
     end
   end
 end


### PR DESCRIPTION
Allows searches by area identifier where no postcode is present. This allows the business-support-finder to lookup schemes by Imminence area slugs as well as postcode.
Depends on [this PR in Imminence](https://github.com/alphagov/imminence/pull/91) and [this PR](https://github.com/alphagov/publisher/pull/234) in Publisher.
