### PR TITLE
Handle (nil) responses for partial postcodes gracefully

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -35,6 +35,8 @@ class Scheme < OpenStruct
 
   def self.area_identifiers(postcode)
     areas_response = imminence_api.areas_for_postcode(postcode)
+    return [] unless areas_response
+
     areas = areas_response["results"].map { |area| area["slug"] }
     areas.join(",")
   end

--- a/spec/features/search_business_support_spec.rb
+++ b/spec/features/search_business_support_spec.rb
@@ -76,5 +76,17 @@ describe "Search for business support" do
       results.first["title"].should == "Graduate start-up scheme"
       results.first["areas"].should == ["london","wales","scotland"]
     end
+
+    it "should return no results with an incomplete postcode" do
+      imminence_has_areas_for_postcode("WC2B",[])
+      facets = { "areas" => ["london", "wales", "scotland"] }
+      content_api_has_business_support_scheme(@graduate_start_up_attrs.merge(facets), facets)
+
+      visit "/business-support-schemes.json?postcode=WC2B"
+
+      parsed_response = JSON.parse(page.body)
+      parsed_response["total"].should == 0
+    end
+
   end
 end


### PR DESCRIPTION
Part of [this story](https://www.agileplannerapp.com/boards/105200/cards/5559)
Returns an empty 'areas' result for a partial postcode.
Partial postcodes are supported by Mapit but additional work is required in Imminence so that's another story.
