### PR TITLE
Add jenkins branch builds script

### DIFF
--- a/jenkins_branches.sh
+++ b/jenkins_branches.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+VENV_PATH="${HOME}/venv/${JOB_NAME}"
+
+[ -x ${VENV_PATH}/bin/pip ] || virtualenv ${VENV_PATH}
+. ${VENV_PATH}/bin/activate
+
+pip install -q ghtools
+
+REPO="alphagov/business-support-api"
+gh-status "$REPO" "$GIT_COMMIT" pending -d "\"Build #${BUILD_NUMBER} is running on Jenkins\"" -u "$BUILD_URL" >/dev/null
+
+if ./jenkins.sh; then
+  gh-status "$REPO" "$GIT_COMMIT" success -d "\"Build #${BUILD_NUMBER} succeeded on Jenkins\"" -u "$BUILD_URL" >/dev/null
+  exit 0
+else
+  gh-status "$REPO" "$GIT_COMMIT" failure -d "\"Build #${BUILD_NUMBER} failed on Jenkins\"" -u "$BUILD_URL" >/dev/null
+  exit 1
+fi


### PR DESCRIPTION
There is a more modern jenkins script that can handle master and branches
in one script, however there are quite a few versions of that floating
around and not a clear one to copy from.

Rather than get hung up on that I want to get the testing in now, so we
can release the rails security update, and revisit the shell scripts
later