### PR TITLE
Add a startup.sh following in the footsteps of our other apps

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+bundle install
+bundle exec rails s -p 3061


### PR DESCRIPTION
- I was finding that it was useful to start business-support-api
  outside of `bowl`, using `bowl`'s `--without` flag. We shouldn't have
  to remember which port to set when running `rails s`, so add a
  `startup.sh` to make it easier.