### PR TITLE
Whitelist area types the Business Support Finder should care about

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -5,6 +5,9 @@ class Scheme < OpenStruct
   extend GdsApi::Helpers
 
   FACET_KEYS = [:areas, :business_sizes, :locations, :sectors, :stages, :support_types]
+  # This list should stay in sync with Publisher's AREA_TYPES list
+  # (https://github.com/alphagov/publisher/blob/master/app/models/area.rb#L7).
+  WHITELISTED_AREA_CODES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA"]
 
   def self.lookup(params={})
 
@@ -37,7 +40,9 @@ class Scheme < OpenStruct
     areas_response = imminence_api.areas_for_postcode(postcode)
     return [] unless areas_response
 
-    areas = areas_response["results"].map { |area| area["slug"] }
-    areas.join(",")
+    areas = areas_response["results"].map do |area|
+      area["slug"] if WHITELISTED_AREA_CODES.include?(area["type"])
+    end
+    areas.reject(&:blank?).join(",")
   end
 end

--- a/spec/features/search_business_support_spec.rb
+++ b/spec/features/search_business_support_spec.rb
@@ -55,7 +55,7 @@ describe "Search for business support" do
     end
 
     it "should filter the schemes by facet values and areas" do
-      imminence_has_areas_for_postcode("WC2B%206SE",[{"slug" => "london", "name" => "London"}])
+      imminence_has_areas_for_postcode("WC2B%206SE",[{"slug" => "london", "name" => "London", "type" => "EUR"}])
       facets = {
           "areas" => ["london", "wales", "scotland"],
           "business_sizes" => ["up-to-249"],

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -83,4 +83,16 @@ describe Scheme do
       s.details.should == { "foo" => "foo", "bar" => "bar" }
     end
   end
+
+  describe "area codes returned from imminence" do
+    it "should only use whitelisted area types" do
+      area1 = {"slug"=>"north-east", "name"=>"North East", "country_name"=>"England", "type"=>"LAC"}
+      area2 = {"slug"=>"european-parliament", "name"=>"European Parliament", "country_name"=>"-", "type"=>"EUP"}
+      area3 = {"slug"=>"london", "name"=>"London", "country_name"=>"England", "type"=>"EUR"}
+      area4 = {"slug"=>"", "name"=>"Blank Slug", "country_name"=>"England", "type"=>"BLK"}
+
+      GdsApi::Imminence.any_instance.stub(:areas_for_postcode).and_return("results" => [area1,area2,area3])
+      Scheme.area_identifiers("E5 9LR").should == 'london'
+    end
+  end
 end


### PR DESCRIPTION
- We shouldn't be caring about London Assembly Constituencies. Some of
  them are named like "North East" or "South West", and returned from
  MapIt, causing this API to then query the content API for things in
  the "North East" as it interprets it as an area. This means that for
  some London postcodes results are returned in Northumberland (ie the
  North East of the country). In the same way, we shouldn't care about
  any type of Ward, either.
- Fix a failing test by adding `"type" => "EUR"` (a whitelisted type, not none) to the test data.

Trello ticket: https://trello.com/c/SCKljEPt/37-business-support-api-should-only-consider-whitelisted-area-types-from-mapit.

(Excuse the branch name - I initially made it a blacklist, but then it was suggested that seeing what valid types were would be a better solution, hence it is now a whitelist.)

Thanks to @jennyd for pairing with the initial investigation into why postcodes in the south were displaying results in the north, and @dsingleton for pairing on the test.