### PR TITLE
Query Content API using area GSS codes

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -4,13 +4,20 @@ require 'gds_api/helpers'
 class Scheme < OpenStruct
   extend GdsApi::Helpers
 
-  FACET_KEYS = [:areas, :business_sizes, :locations, :sectors, :stages, :support_types]
+  FACET_KEYS = [
+    :areas,
+    :business_sizes,
+    :locations,
+    :sectors,
+    :stages,
+    :support_types,
+  ]
+
   # This list should stay in sync with Publisher's AREA_TYPES list
   # (https://github.com/alphagov/publisher/blob/master/app/models/area.rb#L7).
   WHITELISTED_AREA_CODES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA"]
 
   def self.lookup(params={})
-
     postcode = params.delete(:postcode)
     params[:areas] = area_identifiers(postcode) if postcode
 

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -5,7 +5,7 @@ class Scheme < OpenStruct
   extend GdsApi::Helpers
 
   FACET_KEYS = [
-    :areas,
+    :area_gss_codes,
     :business_sizes,
     :locations,
     :sectors,
@@ -19,7 +19,7 @@ class Scheme < OpenStruct
 
   def self.lookup(params={})
     postcode = params.delete(:postcode)
-    params[:areas] = area_identifiers(postcode) if postcode
+    params[:area_gss_codes] = area_identifiers(postcode) if postcode
 
     response = content_api.business_support_schemes(params)
 
@@ -41,7 +41,7 @@ class Scheme < OpenStruct
     return [] unless areas_response
 
     areas = areas_response["results"].map do |area|
-      area["slug"] if WHITELISTED_AREA_CODES.include?(area["type"])
+      area["codes"]["gss"] if WHITELISTED_AREA_CODES.include?(area["type"])
     end
     areas.reject(&:blank?).join(",")
   end

--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -32,13 +32,6 @@ class Scheme < OpenStruct
     Scheme.new(content_api.artefact(slug).to_hash)
   end
 
-  def initialize(artefact = {})
-    super()
-    artefact.each do |k,v|
-      self.send("#{k}=", v)
-    end
-  end
-
   def as_json(options={})
     self.marshal_dump
   end

--- a/spec/features/search_business_support_spec.rb
+++ b/spec/features/search_business_support_spec.rb
@@ -34,14 +34,14 @@ describe "Search for business support" do
     end
     it "should filter the schemes by facet values" do
        facets = {
-          "areas" => ["london"],
+          "area_gss_codes" => ["E15000007"],
           "business_sizes" => ["up-to-249"],
           "sectors" => ["education"],
           "stages" => ["grow-and-sustain"]
         }
       content_api_has_business_support_scheme(@graduate_start_up_attrs.merge(facets), facets)
 
-      visit "/business-support-schemes.json?areas=london&business_sizes=up-to-249&sectors=education&stages=grow-and-sustain"
+      visit "/business-support-schemes.json?area_gss_codes=E15000007&business_sizes=up-to-249&sectors=education&stages=grow-and-sustain"
 
       parsed_response = JSON.parse(page.body)
       parsed_response["total"].should == 1
@@ -51,7 +51,7 @@ describe "Search for business support" do
       parsed_response["pages"].should == 1
       results = parsed_response["results"]
       results.first["title"].should == "Graduate start-up scheme"
-      results.first["areas"].should == ["london"]
+      results.first["area_gss_codes"].should == ["E15000007"]
     end
 
     it "should filter the schemes by facet values and areas" do
@@ -65,7 +65,7 @@ describe "Search for business support" do
       }
       imminence_has_areas_for_postcode("WC2B%206SE", [london])
       facets = {
-          "areas" => ["london", "wales", "scotland"],
+          "area_gss_codes" => ["E15000007", "W08000001", "S15000001"],
           "business_sizes" => ["up-to-249"],
           "sectors" => ["education"],
           "stages" => ["grow-and-sustain"]
@@ -82,12 +82,12 @@ describe "Search for business support" do
       parsed_response["pages"].should == 1
       results = parsed_response["results"]
       results.first["title"].should == "Graduate start-up scheme"
-      results.first["areas"].should == ["london","wales","scotland"]
+      results.first["area_gss_codes"].should == ["E15000007", "W08000001", "S15000001"]
     end
 
     it "should return no results with an incomplete postcode" do
       imminence_has_areas_for_postcode("WC2B",[])
-      facets = { "areas" => ["london", "wales", "scotland"] }
+      facets = { "area_gss_codes" => ["E15000007", "W08000001", "S15000001"] }
       content_api_has_business_support_scheme(@graduate_start_up_attrs.merge(facets), facets)
 
       visit "/business-support-schemes.json?postcode=WC2B"

--- a/spec/features/search_business_support_spec.rb
+++ b/spec/features/search_business_support_spec.rb
@@ -55,7 +55,15 @@ describe "Search for business support" do
     end
 
     it "should filter the schemes by facet values and areas" do
-      imminence_has_areas_for_postcode("WC2B%206SE",[{"slug" => "london", "name" => "London", "type" => "EUR"}])
+      london = {
+        "slug" => "london",
+        "name" => "London",
+        "type" => "EUR",
+        "codes" => {
+          "gss" => "E15000007",
+        },
+      }
+      imminence_has_areas_for_postcode("WC2B%206SE", [london])
       facets = {
           "areas" => ["london", "wales", "scotland"],
           "business_sizes" => ["up-to-249"],

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Scheme do
-
   describe "looking up schemes" do
     before :each do
       @sector = 'health'
@@ -9,54 +8,74 @@ describe Scheme do
       @size = 'under-10'
       @support_types = %w(finance loan)
       @location = 'wales'
-      GdsApi::ContentApi.any_instance.stub(:business_support_schemes).and_return("results" => [])
+
+      GdsApi::ContentApi.any_instance.stub(:business_support_schemes)
+        .and_return("results" => [])
     end
 
     after :each do
-      # Necessary to prevent stack level too deep errors caused by objects with stubs
-      # applied being persisted between requests.
+      # Necessary to prevent stack level too deep errors caused by objects with
+      # stubs applied being persisted between requests.
       Scheme.instance_variable_set('@content_api', nil)
     end
 
     it "should fetch the schemes from content_api" do
-      GdsApi::ContentApi.any_instance.should_receive(:business_support_schemes).
-        with(:sectors => @sector, :stages => @stage, :business_sizes => @size, :support_types => @support_types, :locations => @location).
-          and_return("results" => [])
+      GdsApi::ContentApi.any_instance.should_receive(:business_support_schemes)
+        .with(
+          :sectors => @sector,
+          :stages => @stage,
+          :business_sizes => @size,
+          :support_types => @support_types,
+          :locations => @location,
+        )
+        .and_return("results" => [])
 
-      Scheme.lookup(:sectors => @sector, :stages => @stage, :business_sizes => @size, :support_types => @support_types, :locations => @location)
+      Scheme.lookup(
+        :sectors => @sector,
+        :stages => @stage,
+        :business_sizes => @size,
+        :support_types => @support_types,
+        :locations => @location,
+      )
     end
 
     it "should construct instances of Scheme for each result and return them" do
       facets = {
-        'business_sizes' => [], 'locations' => ['england'],
-        'sectors' => ['manufacturing'], 'stages' => [], 'support_types' => ['grant']
+        'business_sizes' => [],
+        'locations' => ['england'],
+        'sectors' => ['manufacturing'],
+        'stages' => [],
+        'support_types' => ['grant'],
       }
 
       artefact1 = {'identifier' => '666', 'title' => 'artefact1'}.merge(facets)
       artefact2 = {'identifier' => '999', 'title' => 'artefact2'}.merge(facets)
 
-      GdsApi::ContentApi.any_instance.stub(:business_support_schemes).
-        and_return("results" => [artefact1, artefact2])
+      GdsApi::ContentApi.any_instance.stub(:business_support_schemes)
+        .and_return("results" => [artefact1, artefact2])
 
       Scheme.should_receive(:new).with(artefact1).and_return(:scheme1)
       Scheme.should_receive(:new).with(artefact2).and_return(:scheme2)
 
-      schemes = Scheme.lookup(:sectors => @sector, :stage => @stage, :size=> @size,
-                              :support_types => @support_types, :locations => @location)
+      schemes = Scheme.lookup(
+        :sectors => @sector,
+        :stage => @stage,
+        :size => @size,
+        :support_types => @support_types,
+        :locations => @location,
+      )
       schemes.should == [:scheme1, :scheme2]
     end
 
     describe "lookup" do
-
       before do
-
         artefact1 = {"identifier" => "1", "title" => "artefact1"}
         artefact2 = {"identifier" => "2", "title" => "artefact2"}
         artefact3 = {"identifier" => "3", "title" => "artefact3"}
         artefact4 = {"identifier" => "4", "title" => "artefact4"}
 
-        GdsApi::ContentApi.any_instance.stub(:business_support_schemes).
-          and_return("results" => [artefact4, artefact1, artefact3, artefact2])
+        GdsApi::ContentApi.any_instance.stub(:business_support_schemes)
+          .and_return("results" => [artefact4, artefact1, artefact3, artefact2])
 
         Scheme.should_receive(:new).with(artefact1).and_return(:scheme1)
         Scheme.should_receive(:new).with(artefact2).and_return(:scheme2)
@@ -65,18 +84,28 @@ describe Scheme do
       end
 
       it "should order the schemes by contentapi result order" do
-        schemes = Scheme.lookup(:sectors => @sector, :stage => @stage, :size => @size, :support_types => @support_types, :location => @location)
+        schemes = Scheme.lookup(
+          :sectors => @sector,
+          :stage => @stage,
+          :size => @size,
+          :support_types => @support_types,
+          :location => @location,
+        )
         schemes.should == [:scheme4, :scheme1, :scheme3, :scheme2]
       end
     end
-
   end
 
   describe "constructing from content_api artefact hash" do
     it "should assign all top-level fields to the openstruct" do
-      s = Scheme.new("foo" => "bar", "something_else" => "wibble", "details" => {
-        "foo" => "foo", "bar" => "bar"
-      })
+      s = Scheme.new(
+        "foo" => "bar",
+        "something_else" => "wibble",
+        "details" => {
+          "foo" => "foo",
+          "bar" => "bar",
+        },
+      )
 
       s.foo.should == "bar"
       s.something_else.should == "wibble"
@@ -86,12 +115,34 @@ describe Scheme do
 
   describe "area codes returned from imminence" do
     it "should only use whitelisted area types" do
-      area1 = {"slug"=>"north-east", "name"=>"North East", "country_name"=>"England", "type"=>"LAC"}
-      area2 = {"slug"=>"european-parliament", "name"=>"European Parliament", "country_name"=>"-", "type"=>"EUP"}
-      area3 = {"slug"=>"london", "name"=>"London", "country_name"=>"England", "type"=>"EUR"}
-      area4 = {"slug"=>"", "name"=>"Blank Slug", "country_name"=>"England", "type"=>"BLK"}
+      area1 = {
+        "slug" => "north-east",
+        "name" => "North East",
+        "country_name" => "England",
+        "type" => "LAC",
+      }
+      area2 = {
+        "slug" => "european-parliament",
+        "name" => "European Parliament",
+        "country_name" => "-",
+        "type" => "EUP",
+      }
+      area3 = {
+        "slug" => "london",
+        "name" => "London",
+        "country_name" => "England",
+        "type" => "EUR",
+      }
+      area4 = {
+        "slug" => "",
+        "name" => "Blank Slug",
+        "country_name" => "England",
+        "type" => "BLK",
+      }
 
-      GdsApi::Imminence.any_instance.stub(:areas_for_postcode).and_return("results" => [area1,area2,area3])
+      GdsApi::Imminence.any_instance.stub(:areas_for_postcode)
+        .and_return("results" => [area1,area2,area3])
+
       Scheme.area_identifiers("E5 9LR").should == 'london'
     end
   end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -146,7 +146,7 @@ describe Scheme do
       GdsApi::Imminence.any_instance.stub(:areas_for_postcode)
         .and_return("results" => [area1,area2,area3])
 
-      Scheme.area_identifiers("E5 9LR").should == 'london'
+      Scheme.area_identifiers("E5 9LR").should == "E15000007"
     end
   end
 end

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -120,18 +120,27 @@ describe Scheme do
         "name" => "North East",
         "country_name" => "England",
         "type" => "LAC",
+        "codes" => {
+          "gss" => "E32000012",
+        },
       }
       area2 = {
         "slug" => "european-parliament",
         "name" => "European Parliament",
         "country_name" => "-",
         "type" => "EUP",
+        "codes" => {
+          "gss" => nil,
+        },
       }
       area3 = {
         "slug" => "london",
         "name" => "London",
         "country_name" => "England",
         "type" => "EUR",
+        "codes" => {
+          "gss" => "E15000007",
+        },
       }
 
       GdsApi::Imminence.any_instance.stub(:areas_for_postcode)

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -133,12 +133,6 @@ describe Scheme do
         "country_name" => "England",
         "type" => "EUR",
       }
-      area4 = {
-        "slug" => "",
-        "name" => "Blank Slug",
-        "country_name" => "England",
-        "type" => "BLK",
-      }
 
       GdsApi::Imminence.any_instance.stub(:areas_for_postcode)
         .and_return("results" => [area1,area2,area3])


### PR DESCRIPTION
We're changing Business Support Schemes to use (the more stable, less likely to change) GSS area codes instead of slugified area names.

Those area slugs are used in two ways when querying Business Support Schemes by location:
  - provided with a postcode, we use Imminence to get a list of matching area slugs and use them when querying Content API,
  - provided with a comma-separated list of area slugs, we send them directly to Content API.

This pull request swaps the use of area slugs for GSS codes in both cases.

Part of this story https://trello.com/c/XsykRbHp/45-publisher-and-business-support-api-should-use-gss-codes