### PR TITLE
Allow Isles of Scilly in tags

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -13,9 +13,11 @@ class Scheme < OpenStruct
     :support_types,
   ]
 
-  # This list should stay in sync with Publisher's AREA_TYPES list
-  # (https://github.com/alphagov/publisher/blob/master/app/models/area.rb#L7).
-  WHITELISTED_AREA_CODES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA"]
+  # This list should stay in sync with Publisher's Area::AREA_TYPES list:
+  # https://github.com/alphagov/publisher/blob/master/app/models/area.rb#L7-L10
+  # and Imminences areas route constraint:
+  # https://github.com/alphagov/imminence/blob/master/config/routes.rb#L13-L17
+  WHITELISTED_AREA_CODES = ["EUR", "CTY", "DIS", "LBO", "LGD", "MTD", "UTA", "COI"]
 
   def self.lookup(params={})
     postcode = params.delete(:postcode)


### PR DESCRIPTION
They have their own special area type in mapit (COI) so we have to add
it to the list.  Also we update the comment pointing out the other
places that this list needs to be synchronized with.

For: https://trello.com/c/BI5QN49V/308-add-isles-of-scilly-council-to-the-related-areas-tag-available-in-publisher-imminence-3

This doesn't live on it's own, it will not work unless we also merge / deploy:

* https://github.com/alphagov/imminence/pull/126
* https://github.com/alphagov/publisher/pull/449