### PR TITLE
Stop stubbing imminence responses to include slugs

### DIFF
--- a/spec/features/search_business_support_spec.rb
+++ b/spec/features/search_business_support_spec.rb
@@ -56,7 +56,6 @@ describe "Search for business support" do
 
     it "should filter the schemes by facet values and areas" do
       london = {
-        "slug" => "london",
         "name" => "London",
         "type" => "EUR",
         "codes" => {

--- a/spec/models/scheme_spec.rb
+++ b/spec/models/scheme_spec.rb
@@ -116,7 +116,6 @@ describe Scheme do
   describe "area codes returned from imminence" do
     it "should only use whitelisted area types" do
       area1 = {
-        "slug" => "north-east",
         "name" => "North East",
         "country_name" => "England",
         "type" => "LAC",
@@ -125,7 +124,6 @@ describe Scheme do
         },
       }
       area2 = {
-        "slug" => "european-parliament",
         "name" => "European Parliament",
         "country_name" => "-",
         "type" => "EUP",
@@ -134,7 +132,6 @@ describe Scheme do
         },
       }
       area3 = {
-        "slug" => "london",
         "name" => "London",
         "country_name" => "England",
         "type" => "EUR",


### PR DESCRIPTION
For: https://trello.com/c/PKAohBzb/468-stop-adding-slugs-to-areas-returned-from-mapit-by-imminence-2

Imminence no longer returns slugs so we change our stubbed responses to
do the same.  Thankfully we're not using that data so no implementation
needs to change.

See https://github.com/alphagov/imminence/pull/136 for the imminence change