### PR TITLE
Use new GDS API Adapters behaviour

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,14 +5,14 @@ gem 'rails', '4.2.7.1'
 gem 'unicorn', '4.6.3'
 gem 'link_header', '0.0.7'
 
-gem 'plek', '1.7.0'
+gem 'plek', '~> 1.9.0'
 gem 'logstasher', '0.4.8'
 gem 'airbrake', '3.1.15'
 
 if ENV['API_DEV']
   gem 'gds-api-adapters', :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '20.1.1'
+  gem 'gds-api-adapters', '36.0.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,16 +61,16 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    gds-api-adapters (20.1.1)
+    gds-api-adapters (36.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashdiff (0.3.0)
@@ -100,13 +100,13 @@ GEM
       pkg-config (~> 1.1.7)
     null_logger (0.0.1)
     pkg-config (1.1.7)
-    plek (1.7.0)
+    plek (1.9.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rack (1.6.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -136,10 +136,10 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (11.2.2)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -183,7 +183,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.6.3)
       kgio (~> 2.6)
       rack
@@ -202,13 +202,16 @@ DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (~> 2.6.2)
   ci_reporter_rspec
-  gds-api-adapters (= 20.1.1)
+  gds-api-adapters (= 36.0.0)
   link_header (= 0.0.7)
   logstasher (= 0.4.8)
-  plek (= 1.7.0)
+  plek (~> 1.9.0)
   pry
   rails (= 4.2.7.1)
   rspec-rails (~> 3.4.2)
   simplecov-rcov (= 0.2.3)
   unicorn (= 4.6.3)
   webmock (~> 1.24.0)
+
+BUNDLED WITH
+   1.11.2

--- a/config/initializers/gds_api_adapters.rb
+++ b/config/initializers/gds_api_adapters.rb
@@ -1,0 +1,4 @@
+GdsApi.configure do |config|
+  config.always_raise_for_not_found = true
+  config.hash_response_for_requests = true
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/B5z6Dq8q/)

Some old behaviour has been deprecated in [gds-api-adapters](https://github.com/alphagov/gds-api-adapters) so we are updating this app to comply with this before it becomes the default. Firstly, a `GdsApi::NotFound` error is now raised when the server returns a 404 or 410.  Secondly, requests now return a hash instead of an OpenStruct.  We have now opted in to this new behaviour. We are also now handling exceptions raised by gds-api-adapters in the `Scheme` model.