### PR TITLE
Handle 404 response from imminence when getting areas for postcode

### DIFF
--- a/app/models/scheme.rb
+++ b/app/models/scheme.rb
@@ -49,14 +49,12 @@ class Scheme < OpenStruct
   end
 
   def self.area_identifiers(postcode)
-  begin
     areas_response = imminence_api.areas_for_postcode(postcode)
-  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
-    []
-  end
     areas = areas_response["results"].map do |area|
       area["codes"]["gss"] if WHITELISTED_AREA_CODES.include?(area["type"])
     end
     areas.reject(&:blank?).join(",")
+  rescue GdsApi::HTTPNotFound, GdsApi::HTTPGone
+    []
   end
 end


### PR DESCRIPTION
As noted in the comment, imminence doesn't actually respond with an HTTP
404 if the provided postcode doesn't exist.  It returns a 200 with no
results, and a 404 in the _response_info.status.  This is unlikely to be
how we really want imminence to behave and if it does change the old code
would break (`NoMethodError` for `[]` on `nil` where we try to get `["results"]`
from the `area_respones`).  We add a spec and fix the implementation to
avoid this.