### PR TITLE
Add deprecation warning

### DIFF
--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -5,6 +5,7 @@ class BusinessSupportController < ApplicationController
 
   before_filter :set_expiry
   before_filter :only_json
+  before_filter :warning_http_header
 
   include Pagination
 
@@ -54,6 +55,10 @@ class BusinessSupportController < ApplicationController
 
   def only_json
     render :nothing => true, :status => 406 unless params[:format] == 'json'
+  end
+
+  def warning_http_header
+    response.headers["Warning"] = '299 - "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"'
   end
 
 end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -14,6 +14,7 @@ class PaginationPresenter
         :status => "ok",
         :links => link_helper.links,
       },
+      :_warning => "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes",
       :total => results.total,
       :start_index => results.start_index,
       :page_size => results.results.size,

--- a/app/presenters/scheme_presenter.rb
+++ b/app/presenters/scheme_presenter.rb
@@ -9,6 +9,8 @@ class SchemePresenter
     attrs = @scheme.as_json
     attrs[:id] = @url_helper.build_scheme_url(attrs[:id])
     valid_keys = [:id, :identifier, :title, :details, :web_url, :priority] + Scheme::FACET_KEYS
-    attrs.select { |k,v| valid_keys.include?(k.to_sym) }
+    scheme = attrs.select { |k,v| valid_keys.include?(k.to_sym) }
+    scheme[:_warning] = "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
+    scheme
   end
 end

--- a/spec/controllers/business_support_controller_spec.rb
+++ b/spec/controllers/business_support_controller_spec.rb
@@ -21,6 +21,11 @@ describe BusinessSupportController do
       get :search
       expect(response.status).to eq(406)
     end
+
+    it "should set a deprecation warning header" do
+      get :search, :format => :json
+      expect(response.header['Warning']).to include '299'
+    end
   end
 
   describe "GET show" do
@@ -43,6 +48,11 @@ describe BusinessSupportController do
     it "should deny other formats" do
       get :show, :slug => "foo"
       expect(response.status).to eq(406)
+    end
+
+    it "should set a deprecation warning header" do
+      get :show, :slug => "foo", :format => :json
+      expect(response.header['Warning']).to include '299'
     end
 
     it "should 404 if the slug is not a business support scheme" do

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -7,6 +7,7 @@ describe PaginationPresenter do
   it "should initialize pagination values and paging links" do
     allow_any_instance_of(Plek).to receive(:website_root).and_return("http://test.gov.uk")
 
+    warning = "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
     schemes = []
     25.times { |n| schemes << Scheme.new({:id => "http://test.gov.uk/scheme#{n+1}.json"}) }
 
@@ -22,6 +23,7 @@ describe PaginationPresenter do
     expect(json_hash[:total]).to eq(100)
     expect(json_hash[:pages]).to eq(4)
     expect(json_hash[:results].size).to eq(25)
+    expect(json_hash[:_warning]).to eq(warning)
 
     links = json_hash[:_response_info][:links]
     expect(links.size).to eq(2)

--- a/spec/presenters/scheme_presenter_spec.rb
+++ b/spec/presenters/scheme_presenter_spec.rb
@@ -4,6 +4,7 @@ require 'url_helper'
 describe "SchemePresenter" do
   it "should format the scheme as json" do
     allow_any_instance_of(Plek).to receive(:website_root).and_return("http://test.gov.uk")
+    warning = "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
     scheme = Scheme.new({
       :id => "http://foo.com/bar/baz.json",
       :identifier => "1234",
@@ -21,5 +22,6 @@ describe "SchemePresenter" do
     expect(json_hash[:identifier]).to eq("1234")
     expect(json_hash[:title]).to eq("Baz and all that jazz")
     expect(json_hash[:details]).to eq({:additional_information => "Bloop"})
+    expect(json_hash[:_warning]).to eq(warning)
   end
 end


### PR DESCRIPTION
This commit adds a deprecation warning to all endpoints to make users aware of the pending deprecation of this API. The warning is set both as a value in the returned JSON and an HTTP header.

Trello: https://trello.com/c/VzGgfFCS/528-add-a-deprecation-notice-to-the-api-response