### PR TITLE
Update deprecation warning with new date

### DIFF
--- a/app/controllers/business_support_controller.rb
+++ b/app/controllers/business_support_controller.rb
@@ -58,7 +58,7 @@ class BusinessSupportController < ApplicationController
   end
 
   def warning_http_header
-    response.headers["Warning"] = '299 - "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"'
+    response.headers["Warning"] = '299 - "The business support API is now deprecated and will be removed on Monday 24 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"'
   end
 
 end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -14,7 +14,7 @@ class PaginationPresenter
         :status => "ok",
         :links => link_helper.links,
       },
-      :_warning => "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes",
+      :_warning => "The business support API is now deprecated and will be removed on Monday 24 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes",
       :total => results.total,
       :start_index => results.start_index,
       :page_size => results.results.size,

--- a/app/presenters/scheme_presenter.rb
+++ b/app/presenters/scheme_presenter.rb
@@ -10,7 +10,7 @@ class SchemePresenter
     attrs[:id] = @url_helper.build_scheme_url(attrs[:id])
     valid_keys = [:id, :identifier, :title, :details, :web_url, :priority] + Scheme::FACET_KEYS
     scheme = attrs.select { |k,v| valid_keys.include?(k.to_sym) }
-    scheme[:_warning] = "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
+    scheme[:_warning] = "The business support API is now deprecated and will be removed on Monday 24 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
     scheme
   end
 end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -7,7 +7,7 @@ describe PaginationPresenter do
   it "should initialize pagination values and paging links" do
     allow_any_instance_of(Plek).to receive(:website_root).and_return("http://test.gov.uk")
 
-    warning = "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
+    warning = "The business support API is now deprecated and will be removed on Monday 24 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
     schemes = []
     25.times { |n| schemes << Scheme.new({:id => "http://test.gov.uk/scheme#{n+1}.json"}) }
 

--- a/spec/presenters/scheme_presenter_spec.rb
+++ b/spec/presenters/scheme_presenter_spec.rb
@@ -4,7 +4,7 @@ require 'url_helper'
 describe "SchemePresenter" do
   it "should format the scheme as json" do
     allow_any_instance_of(Plek).to receive(:website_root).and_return("http://test.gov.uk")
-    warning = "The business support API is now deprecated and will be removed on Tuesday 18 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
+    warning = "The business support API is now deprecated and will be removed on Monday 24 April 2017; please use https://www.gov.uk/api/search.json?filter_document_type=business_finance_support_scheme instead to get all schemes"
     scheme = Scheme.new({
       :id => "http://foo.com/bar/baz.json",
       :identifier => "1234",


### PR DESCRIPTION
This commit updates the deprecation warning with a new date. This date takes into account the schedule for publishing a blog post about this change.

Trello: https://trello.com/c/VzGgfFCS/528-add-a-deprecation-notice-to-the-api-response